### PR TITLE
[Stage] add stage skeleton to separate the opening and the playing ga…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     testImplementation 'io.kotlintest:kotlintest-runner-junit5:3.3.2'
+    testImplementation "io.mockk:mockk:1.9.3"
 }
 
 compileKotlin {

--- a/src/main/kotlin/fr/tvbarthel/mtg/engine/GameEngine.kt
+++ b/src/main/kotlin/fr/tvbarthel/mtg/engine/GameEngine.kt
@@ -1,9 +1,17 @@
 package fr.tvbarthel.mtg.engine
 
+import fr.tvbarthel.mtg.engine.opening.OpeningInput
+import fr.tvbarthel.mtg.engine.opening.OpeningStage
+import fr.tvbarthel.mtg.engine.playing.PlayingInput
+import fr.tvbarthel.mtg.engine.playing.PlayingStage
+
 /**
  * Game engine supposed to be able to play an MTG game.
  */
-class GameEngine {
+class GameEngine(
+    val openingStage: OpeningStage = OpeningStage(),
+    val playingStage: PlayingStage = PlayingStage()
+) {
 
     /**
      * Simulate a complete game of MTG.
@@ -11,6 +19,8 @@ class GameEngine {
      * @return output of the game - ake game result.
      */
     fun simulate(config: GameConfig): GameResult {
-        return GameResult(config)
+        val openingOutput = openingStage.proceed(OpeningInput())
+        val playingOutput = playingStage.proceed(PlayingInput())
+        return GameResult(config, openingOutput, playingOutput)
     }
 }

--- a/src/main/kotlin/fr/tvbarthel/mtg/engine/GameResult.kt
+++ b/src/main/kotlin/fr/tvbarthel/mtg/engine/GameResult.kt
@@ -1,8 +1,16 @@
 package fr.tvbarthel.mtg.engine
 
+import fr.tvbarthel.mtg.engine.opening.OpeningOutput
+import fr.tvbarthel.mtg.engine.playing.PlayingOutput
+
 /**
  * Encapsulate every game output.
  * @param config game input which lead to the given result.
- * @param turn number of total turn played for this game.
+ * @param openingResult result of the opening stage.
+ * @param playingResult result of the playing stage.
  */
-data class GameResult(val config: GameConfig, val turn: Int = 0)
+data class GameResult(
+    val config: GameConfig,
+    val openingResult: OpeningOutput,
+    val playingResult: PlayingOutput
+)

--- a/src/main/kotlin/fr/tvbarthel/mtg/engine/GameState.kt
+++ b/src/main/kotlin/fr/tvbarthel/mtg/engine/GameState.kt
@@ -1,0 +1,3 @@
+package fr.tvbarthel.mtg.engine
+
+data class GameState(val seed: Long, val turn: Int = 0)

--- a/src/main/kotlin/fr/tvbarthel/mtg/engine/Stage.kt
+++ b/src/main/kotlin/fr/tvbarthel/mtg/engine/Stage.kt
@@ -1,0 +1,13 @@
+package fr.tvbarthel.mtg.engine
+
+/**
+ * Encapsulate highest "step" of the game engine.
+ */
+interface Stage<in I, out O> {
+
+    /**
+     * Must proceed the given stage.
+     */
+    fun proceed(input: I): O
+
+}

--- a/src/main/kotlin/fr/tvbarthel/mtg/engine/opening/OpeningInput.kt
+++ b/src/main/kotlin/fr/tvbarthel/mtg/engine/opening/OpeningInput.kt
@@ -1,0 +1,6 @@
+package fr.tvbarthel.mtg.engine.opening
+
+/**
+ * Encapsulate every input param for the [OpeningStage]
+ */
+class OpeningInput

--- a/src/main/kotlin/fr/tvbarthel/mtg/engine/opening/OpeningOutput.kt
+++ b/src/main/kotlin/fr/tvbarthel/mtg/engine/opening/OpeningOutput.kt
@@ -1,0 +1,6 @@
+package fr.tvbarthel.mtg.engine.opening
+
+/**
+ * Encapsulate every ouput param for the [OpeningStage]
+ */
+class OpeningOutput

--- a/src/main/kotlin/fr/tvbarthel/mtg/engine/opening/OpeningStage.kt
+++ b/src/main/kotlin/fr/tvbarthel/mtg/engine/opening/OpeningStage.kt
@@ -1,0 +1,12 @@
+package fr.tvbarthel.mtg.engine.opening
+
+import fr.tvbarthel.mtg.engine.Stage
+
+/**
+ * [Stage] which must ensure the opening stage.
+ */
+class OpeningStage : Stage<OpeningInput, OpeningOutput> {
+    override fun proceed(input: OpeningInput): OpeningOutput {
+        return OpeningOutput()
+    }
+}

--- a/src/main/kotlin/fr/tvbarthel/mtg/engine/playing/PlayingInput.kt
+++ b/src/main/kotlin/fr/tvbarthel/mtg/engine/playing/PlayingInput.kt
@@ -1,0 +1,6 @@
+package fr.tvbarthel.mtg.engine.playing
+
+/**
+ * Encapsulate every input param for the [PlayingStage]
+ */
+class PlayingInput

--- a/src/main/kotlin/fr/tvbarthel/mtg/engine/playing/PlayingOutput.kt
+++ b/src/main/kotlin/fr/tvbarthel/mtg/engine/playing/PlayingOutput.kt
@@ -1,0 +1,6 @@
+package fr.tvbarthel.mtg.engine.playing
+
+/**
+ * Encapsulate every output param for the [PlayingStage]
+ */
+class PlayingOutput

--- a/src/main/kotlin/fr/tvbarthel/mtg/engine/playing/PlayingStage.kt
+++ b/src/main/kotlin/fr/tvbarthel/mtg/engine/playing/PlayingStage.kt
@@ -1,0 +1,12 @@
+package fr.tvbarthel.mtg.engine.playing
+
+import fr.tvbarthel.mtg.engine.Stage
+
+/**
+ * [Stage] which must ensure the opening stage.
+ */
+class PlayingStage : Stage<PlayingInput, PlayingOutput> {
+    override fun proceed(input: PlayingInput): PlayingOutput {
+        return PlayingOutput()
+    }
+}

--- a/src/test/kotlin/fr/tvbarthel/mtg/engine/GameEngineTest.kt
+++ b/src/test/kotlin/fr/tvbarthel/mtg/engine/GameEngineTest.kt
@@ -1,22 +1,40 @@
 package fr.tvbarthel.mtg.engine
 
+import fr.tvbarthel.mtg.engine.opening.OpeningStage
+import fr.tvbarthel.mtg.engine.playing.PlayingStage
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.verifyOrder
 
 /**
  * Ensure that [GameEngine] behavior if the expected one and won't break in the future.
  */
-class GameEngineTest : StringSpec({
+class GameEngineTest : StringSpec() {
 
-    "given most simple config when simulate then right result" {
-        // given
-        val config = GameConfig()
+    @RelaxedMockK
+    lateinit var openingStage: OpeningStage
 
-        // when
-        val result = GameEngine().simulate(config)
+    @RelaxedMockK
+    lateinit var playingStage: PlayingStage
 
-        // then
-        result.config shouldBe config
-        result.turn shouldBe 0
+    init {
+        MockKAnnotations.init(this)
+
+        "given most simple config when simulate then right result" {
+            // given
+            val config = GameConfig()
+
+            // when
+            val result = GameEngine(openingStage, playingStage).simulate(config)
+
+            // then
+            result.config shouldBe config
+            verifyOrder {
+                openingStage.proceed(any())
+                playingStage.proceed(any())
+            }
+        }
     }
-})
+}


### PR DESCRIPTION
[Stage] add stage skeleton to separate the opening and the playing game "phase"

Since phase is already a keyword used by the MTG turn structure, try to add
the new keywork stage to define the highest unit of a MTG game part.